### PR TITLE
fix: add missing peripherals

### DIFF
--- a/library/types/peripheral.lua
+++ b/library/types/peripheral.lua
@@ -16,7 +16,10 @@
 ---| '"monitor"'
 ---| '"printer"'
 ---| '"speaker"'
+---| '"energy_storage"'
+---| '"fluid_storage"'
 ---| '"inventory"'
+---| string
 
 ---@alias wrappedPeripheral Command|Computer|Drive|EnergyStorage|FluidStorage|Inventory|Modem|Monitor|Printer|Speaker|WiredModem
 


### PR DESCRIPTION
This PR adds `energy_storage`, `fluid_storage` and string as valid types for `peripheralType`.

string, because other mods can provide custom peripheral types like with Tinker's Construct `tconstruct:drain`.