### PR TITLE
fix big text issues in some descriptions

### DIFF
--- a/library/cc/strings.lua
+++ b/library/cc/strings.lua
@@ -1,6 +1,7 @@
 ---@meta
 
 ---Utilities for strings and text
+---
 ------
 ---[Official Documentation](https://tweaked.cc/library/cc.strings.html)
 strings = {}

--- a/library/colors.lua
+++ b/library/colors.lua
@@ -14,6 +14,7 @@
 ---the nearest tint of gray. You can check if a terminal supports color by using
 ---the function `term.isColor`. Grayscale colors are calculated by taking the
 ---average of the three components, i.e. `(red + green + blue) / 3`.
+---
 ------
 ---[Official Documentation](https://tweaked.cc/module/colors.html)
 colors = {}

--- a/library/fs.lua
+++ b/library/fs.lua
@@ -14,6 +14,7 @@
 ---
 ---Most filesystems have a finite capacity and trying to perform an operation
 ---that could exceed it will fail
+---
 ------
 ---[Official Documentation](https://tweaked.cc/module/fs.html)
 fs = {}

--- a/library/gps.lua
+++ b/library/gps.lua
@@ -13,6 +13,7 @@
 gps = {}
 
 ---The channel that GPS requests and responses are broadcast on
+---
 ------
 ---[Official Documentation](https://tweaked.cc/module/gps.html#v:CHANNEL_GPS)
 gps.CHANNEL_GPS = 65534

--- a/library/keys.lua
+++ b/library/keys.lua
@@ -2,6 +2,7 @@
 
 ---It is reccommended that you use the constant values defined here rather than
 ---any numerical values as they may change between versions
+---
 ------
 ---[Official Documentation](https://tweaked.cc/module/keys.html)
 keys = {

--- a/library/os.lua
+++ b/library/os.lua
@@ -169,11 +169,13 @@ function os.setAlarm(time) end
 function os.cancelAlarm(ID) end
 
 ---Shut down this computer immediately
+---
 ------
 ---[Official Documentation](https://tweaked.cc/module/os.html#v:shutdown)
 function os.shutdown() end
 
 ---Reboot this computer immediately
+---
 ------
 ---[Official Documentation](https://tweaked.cc/module/os.html#v:reboot)
 function os.reboot() end

--- a/library/rednet.lua
+++ b/library/rednet.lua
@@ -78,7 +78,7 @@ function rednet.send(recipient, message, protocol) end
 ---Every device listening on rednet can receive broadcasted messages
 ---@param message number|boolean|string|table The message to broadcast
 ---@param protocol string The protocol to broadcast the message under
--------
+------
 ---[Official Documentation](https://tweaked.cc/module/rednet.html#v:broadcast)
 function rednet.broadcast(message, protocol) end
 

--- a/library/types/objects/Redirect.lua
+++ b/library/types/objects/Redirect.lua
@@ -52,6 +52,7 @@ function Redirect.setCursorBlink(blink) end
 function Redirect.getSize() end
 
 ---Clears the terminal, filling it with the current background color
+---
 ------
 ---[Official Documentation](https://tweaked.cc/module/term.html#ty:Redirect:clear)
 function Redirect.clear() end

--- a/library/types/objects/http/Websocket.lua
+++ b/library/types/objects/http/Websocket.lua
@@ -3,6 +3,7 @@
 ---A
 ---[websocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API)
 ---that can be used to send/receive messages to/from a web server
+---
 ------
 ---[Official Documentation](https://tweaked.cc/module/http.html#ty:Websocket)
 ---@class ccTweaked.http.Websocket

--- a/library/types/objects/peripheral/Command.lua
+++ b/library/types/objects/peripheral/Command.lua
@@ -2,6 +2,7 @@
 
 ---Command blocks can be used as a peripheral to allow their commands to be
 ---executed using a computer
+---
 ------
 ---[Official Documentation](https://tweaked.cc/peripheral/command.html)
 ---@class ccTweaked.peripheral.Command

--- a/library/types/objects/peripheral/Computer.lua
+++ b/library/types/objects/peripheral/Computer.lua
@@ -4,6 +4,7 @@
 ---
 ---A computer will have the type `computer` while a turtle will have the type
 ---`turtle`
+---
 ------
 ---[Official Documentation](https://tweaked.cc/peripheral/computer.html)
 ---@class ccTweaked.peripheral.Computer

--- a/library/types/objects/peripheral/Drive.lua
+++ b/library/types/objects/peripheral/Drive.lua
@@ -10,6 +10,7 @@
 ---
 ---When a disk is inserted, a `disk` event is fired, with the side peripheral is
 ---on. Likewise, when the disk is detached, a `disk_eject` event is fired.
+---
 ------
 ---[Official Documentation](https://tweaked.cc/peripheral/drive.html)
 ---@class ccTweaked.peripheral.Drive

--- a/library/types/objects/peripheral/Modem.lua
+++ b/library/types/objects/peripheral/Modem.lua
@@ -12,6 +12,7 @@
 ---specififc channels. For example, the `gps` module sends all of its messages on
 ---`gps.CHANNEL_GPS` (default is 65534), while `rednet` uses the channel equal to
 ---the computer's ID
+---
 ------
 ---[Official Documentation](https://tweaked.cc/peripheral/modem.html)
 ---@class ccTweaked.peripheral.Modem

--- a/library/types/objects/peripheral/WiredModem.lua
+++ b/library/types/objects/peripheral/WiredModem.lua
@@ -12,6 +12,7 @@
 ---specififc channels. For example, the `gps` module sends all of its messages on
 ---`gps.CHANNEL_GPS` (default is 65534), while `rednet` uses the channel equal to
 ---the computer's ID
+---
 ------
 ---[Official Documentation](https://tweaked.cc/peripheral/modem.html)
 ---@class ccTweaked.peripheral.WiredModem: ccTweaked.peripheral.Modem


### PR DESCRIPTION
In some function/module descriptions, a formatting issue makes text appear bigger than expected when hovering, this PR fixes all the cases I found.

Before:
![image](https://github.com/user-attachments/assets/512e69f0-859c-4f16-b05c-a881f1417b4e)

After:
![image](https://github.com/user-attachments/assets/34ab0ee7-ed33-400a-915a-e0df6ed5a239)
