### PR TITLE
add missing instruments

### DIFF
--- a/library/types/peripheral.lua
+++ b/library/types/peripheral.lua
@@ -42,6 +42,13 @@
 ---| '"bit"'
 ---| '"banjo"'
 ---| '"pling"'
+---| '"creeper"'
+---| '"custom_head"'
+---| '"dragon"'
+---| '"piglin"'
+---| '"skeleton"'
+---| '"wither_skeleton"'
+---| '"zombie"'
 
 ---@alias ccTweaked.peripheral.soundEffect
 ---| '"ambient.basalt_deltas.additions"'


### PR DESCRIPTION
This PR adds some missing instruments to types

You can find those listed [here](https://minecraft.wiki/w/Note_Block#Block_states)

I tested them, they do work in game like any other instruments