### PR TITLE
Added Item Details structure

### DIFF
--- a/library/types/objects/peripheral/Inventory.lua
+++ b/library/types/objects/peripheral/Inventory.lua
@@ -38,7 +38,7 @@ function Inventory.list() end
 
 ---Get detailed information about an item in this inventory
 ---@param slot integer The slot to get more info about
----@return table|nil info Information about the item in the slot or `nil` if no item is present
+---@return ccTweaked.peripheral.itemDetail|nil info Information about the item in the slot or `nil` if no item is present
 ---@throws If the slot is out of range
 ------
 ---[Official Documentation](https://tweaked.cc/generic_peripheral/inventory.html#v:getItemDetail)

--- a/library/types/peripheral.lua
+++ b/library/types/peripheral.lua
@@ -1046,10 +1046,20 @@
 ---@field nbt string|nil This item's Named Binary Tag
 
 ---@class ccTweaked.peripheral.itemDetails
----@field displayName string display name of the item (server-side language)
----@field itemGroups {displayName:string, id:string}[] list of the item groups this item is in.
----@field mapColor number RGB color code of the block on the map
----@field mapColour number RGB colour code of the block on the map but for british
----@field maxCount number maximum stack size of the item
----@field name string minecraft item id
----@field tags table<string, boolean> tags of the item
+---@field displayName string The translated display name of the item. This uses the server's language. This will typically be English on multi-player servers, and your current language on single player.
+---@field itemGroups {displayName:string, id:string}[] The item groups this item appears on. Each item group is stored as a table, containing its id and display name.
+---This information is not available on Minecraft 1.19.3 to 1.20.3. This field is present, but empty on those versions.
+---@field maxCount number The max possible size of the item stack.
+---@field count number The number of items in the stack.
+---@field name string The namespaced ID for this item, e.g. `minecraft:dirt`. See [the Minecraft wiki](https://minecraft.wiki/w/Java_Edition_data_values#Items) for a list of vanilla item IDs.
+---@field mapColor? number RGB color code of the block on the map
+---@field mapColour? number RGB colour code of the block on the map but for british
+---@field tags? table<string, boolean> The set of tags for this item. This is a mapping of tag name to `true`.
+---@field nbt? string A hash of the NBT in the stack. While this does not expose any information about the item's NBT, it can be used as a way to compare items. If two items have the same `name` and `nbt`, then all other properties (e.g. durability, enchantment) will be the same.
+---@field lore? string[] Additional lore about this item, as a list of strings.
+---@field damage? number The amount of damage this item has taken.
+---@field maxDamage? number The maximum amount of damage this item has taken.
+---@field durability? number If this item is damaged (i.e. the durability bar is visible), the percentage left on the durability bar, between 0 and 1 (inclusive).
+---@field unbreakable? boolean `true`, if the item is unbreakable
+---@field enchantments? {name:string, displayName:string, level:number}[] The enchantments this item has.
+---@field potionEffects? {name: string, displayname: string, duration?:number, potency?:number}[] The effects this item has

--- a/library/types/peripheral.lua
+++ b/library/types/peripheral.lua
@@ -1044,3 +1044,12 @@
 ---@field name string The item name
 ---@field count integer The number of this item present
 ---@field nbt string|nil This item's Named Binary Tag
+
+---@class ccTweaked.peripheral.itemDetails
+---@field displayName string display name of the item (server-side language)
+---@field itemGroups {displayName:string, id:string}[] list of the item groups this item is in.
+---@field mapColor number RGB color code of the block on the map
+---@field mapColour number RGB colour code of the block on the map but for british
+---@field maxCount number maximum stack size of the item
+---@field name string minecraft item id
+---@field tags table<string, boolean> tags of the item


### PR DESCRIPTION
Accordingly to the structure described on https://tweaked.cc/reference/item_details.html for CC:Tweaked 1.64 onwards.

I think it also applies to the turtle things but I'm not sure ? Regardless I implemented the structure at least for inventory.

I was also unsure if it was a good idea to use the same item struct used in `Inventory.list()` as these are small generic structures that will never contain all the item details, whereas `Inventory.getItemDetail(slot)` will always return the item details (obviously)

Please let me know if any change should be done.