### PR TITLE
Fixed namespacing for ccTweaked.Window

### DIFF
--- a/library/types/objects/Window.lua
+++ b/library/types/objects/Window.lua
@@ -1,6 +1,6 @@
 ---@meta
 
----@class Window: ccTweaked.term.Redirect
+---@class ccTweaked.Window: ccTweaked.term.Redirect
 Window = {}
 
 ---Get the buffered contents of a given line in this window

--- a/library/window.lua
+++ b/library/window.lua
@@ -14,7 +14,7 @@ window = {}
 ---@param width number The width of this window
 ---@param height number The height of this window
 ---@param visible? boolean If this window should immediately be visible (defaults to true)
----@return Window window The window object
+---@return ccTweaked.Window window The window object
 ------
 ---[Official Documentation](https://tweaked.cc/module/window.html#v:create)
 function window.create(parent, x, y, width, height, visible) end


### PR DESCRIPTION
Changed `Window` to `ccTweaked.Window` to follow the naming conventions.